### PR TITLE
[SS-1] Fix Docker image tags for new GitHub account

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: elenavo-pm/scheduler-service
 
 jobs:
   build-and-push-images:
@@ -60,7 +59,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-prod:latest
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}-prod:latest
           platforms: linux/amd64,linux/arm64/v8
 
       - name: Add test data for testing stage
@@ -77,5 +76,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-test:latest
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}-test:latest
           platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
Replace `IMAGE_NAME` env variable with the built-in property `github.repository` in GitHub Actions in order Docker images to be pushed to the correct account. 
Property `github.repository` references to the current account name and the current repository name: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

Closes #1 